### PR TITLE
Added an equal symbol to --stats options.

### DIFF
--- a/tips.md
+++ b/tips.md
@@ -9,7 +9,7 @@ subtitle: miscellaneous features
 
 Use `--stats` and related options of `norikra start`.
 
-* `--stats PATH`
+* `--stats=PATH`
   * JSON document, stores:
     * configurations: listen address/port, threads, logging
     * targets and queries
@@ -20,7 +20,7 @@ Use `--stats` and related options of `norikra start`.
 * `--dump-stat-interval=N`
   * store stats dump per specified N seconds (ex: 1800)
 
-Stats will be dumped with SIGUSR2 if `--stats PATH` specified. Or, in client side, `norikra-client admin stats` can export stats json data.
+Stats will be dumped with SIGUSR2 if `--stats=PATH` specified. Or, in client side, `norikra-client admin stats` can export stats json data.
 
 ## Query grouping
 


### PR DESCRIPTION
I'd like to modify the --stats option usage more correctly.
